### PR TITLE
Fix parsing of compact size filters from URL

### DIFF
--- a/algolia-search-results.js
+++ b/algolia-search-results.js
@@ -52,16 +52,26 @@ function normalizeFromUrlSingle(valueOrArray) {
     const sizeMatch = s0.match(
       /^(\d+(?:\.\d+)?)\s*[xX]\s*(\d+(?:\.\d+)?)(?:\s*[xX]\s*(\d+(?:\.\d+)?))?$/
     );
-    let spaced;
+    let sizeVariants = [];
     if (sizeMatch) {
       const parts = sizeMatch.slice(1).filter(Boolean);
-      spaced = parts.join(' x ');      // e.g., "6 x 9" or "9 x 12 x 1"
+      const compact = parts.join('x');
+      const spaced = parts.join(' x ');      // e.g., "6 x 9" or "9 x 12 x 1"
+
+      sizeVariants = [s0, compact, spaced]
+        .map(v => String(v || '').trim())
+        .filter(Boolean);
     } else {
       // previous behavior: hyphens → spaces, title-case words
-      spaced = titleCaseWords(s0.replace(/-/g, ' ')).replace(/\s+/g, ' ').trim();
+      const spaced = titleCaseWords(s0.replace(/-/g, ' ')).replace(/\s+/g, ' ').trim();
+      sizeVariants = [spaced];
     }
 
-    if (spaced) out.push(spaced);
+    if (sizeVariants.length) {
+      for (const variant of dedupeLoose(sizeVariants)) {
+        out.push(variant);
+      }
+    }
   }
   return dedupeLoose(out);
 }


### PR DESCRIPTION
## Summary
- preserve compact size values when normalizing URL refinements so existing filters are reapplied on reload
- keep additional human-friendly size variants without forcing extra searches

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc8f803dd8832fa1584787f931696b