### PR TITLE
Handle size refinements from URLs

### DIFF
--- a/algolia-search-results.js
+++ b/algolia-search-results.js
@@ -43,18 +43,58 @@ function normalizeFromUrlSingle(valueOrArray) {
     const s = String(raw).replace(/\+/g, ' ').trim();
 
     // Special handling for price groups - preserve hyphens for price ranges
-    const isPriceGroup = /^\$?\d+-\$?\d+$/.test(s);
-    let spaced;
-    if (isPriceGroup) {
-      // For price groups like "$1000-$2500", preserve the hyphen
-      spaced = s;
-    } else {
-      // For other values, convert hyphens to spaces as before
-      spaced = titleCaseWords(s.replace(/-/g, ' ')).replace(/\s+/g, ' ').trim();
+    if (/^\$?\d+-\$?\d+$/.test(s)) {
+      out.push(s);
+      continue;
     }
 
-    if (spaced)
-      out.push(spaced);
+    const variants = new Set();
+    const base = titleCaseWords(s.replace(/-/g, ' ')).replace(/\s+/g, ' ').trim();
+    if (base)
+      variants.add(base);
+
+    // Add dimension variants (e.g., 6x9 → 6 x 9, 6' x 9') to match stored facet values
+    const sizeCandidate = s.replace(/[×]/g, 'x');
+    const sizeParts = sizeCandidate.split(/x/i).map(part => part.trim()).filter(Boolean);
+    const sizeLike = sizeParts.length >= 2 && sizeParts.every(part => /^[0-9'"′″\s\/.:-]+$/.test(part));
+    if (sizeLike) {
+      const normalizedParts = sizeParts.map(part => part.replace(/-/g, ' ').replace(/\s+/g, ' ').trim()).filter(Boolean);
+      const joinParts = delim => normalizedParts.join(delim).replace(/\s+/g, ' ').trim();
+      const collapsed = normalizedParts.join('x').replace(/\s+/g, '');
+
+      if (normalizedParts.length) {
+        const spaced = joinParts(' x ');
+        const spacedUpper = joinParts(' X ');
+        if (spaced)
+          variants.add(spaced);
+        if (spacedUpper)
+          variants.add(spacedUpper);
+        if (collapsed)
+          variants.add(collapsed);
+
+        const hasQuote = normalizedParts.some(part => /['"′″]/.test(part));
+        const isPlainNumber = part => /^\d+(?:\s*\d\/\d)?$/.test(part);
+        if (!hasQuote && normalizedParts.every(isPlainNumber)) {
+          const withFeetParts = normalizedParts.map(part => `${part}'`);
+          const withFeet = withFeetParts.join(' x ');
+          const withFeetUpper = withFeetParts.join(' X ');
+          if (withFeet)
+            variants.add(withFeet);
+          if (withFeetUpper)
+            variants.add(withFeetUpper);
+        }
+      }
+    }
+
+    // Keep the raw trimmed value as a fallback
+    if (s)
+      variants.add(s);
+
+    for (const v of variants) {
+      const finalValue = String(v).replace(/\s+/g, ' ').trim();
+      if (finalValue)
+        out.push(finalValue);
+    }
   }
   return dedupeLoose(out);
 }


### PR DESCRIPTION
## Summary
- expand URL normalization to generate size facet variants so query params like `sizes=6x9` map back to real facet values
- keep price-group handling intact and apply the same normalization fix to the optimized landing search script

## Testing
- node - <<'NODE' ... (normalization smoke test)


------
https://chatgpt.com/codex/tasks/task_e_68dc96d426d8832f96aab0f857e47c90