### PR TITLE
Prevent duplicate size refinements from URLs

### DIFF
--- a/algolia-landing-optimized.js
+++ b/algolia-landing-optimized.js
@@ -117,10 +117,22 @@ function dedupe(arr) {
 function dedupeLoose(arr) {
   const out = [];
   const seen = new Set();
-  const key = v => String(v).replace(/[\s-]+/g, '-').toLowerCase();
+  const key = v => {
+    const raw = String(v ?? '').trim();
+    if (!raw) return '';
+
+    const lower = raw.toLowerCase();
+    const sizeish = lower.replace(/[×]/g, 'x');
+    // If the value looks like a size (numbers/quotes around an x), collapse whitespace/punctuation
+    if (/(?:\d|['"′″])\s*x\s*(?:\d|['"′″])/.test(sizeish)) {
+      return sizeish.replace(/[^0-9a-z]+/g, '');
+    }
+
+    return lower.replace(/[\s-]+/g, '-');
+  };
   for (const v of (arr || []).filter(Boolean)) {
     const k = key(v);
-    if (!seen.has(k)) {
+    if (k && !seen.has(k)) {
       seen.add(k);
       out.push(String(v));
     }
@@ -138,17 +150,50 @@ function normalizeFromUrlSingle(valueOrArray) {
   for (const raw of values) {
     if (!raw) continue;
     const s = String(raw).replace(/\+/g, ' ').trim();
-    
+
     // Special handling for price groups - preserve hyphens for price ranges
-    const isPriceGroup = /^\$?\d+-\$?\d+$/.test(s);
-    let spaced;
-    if (isPriceGroup) {
-      spaced = s;
-    } else {
-      spaced = titleCaseWords(s.replace(/-/g, ' ')).replace(/\s+/g, ' ').trim();
+    if (/^\$?\d+-\$?\d+$/.test(s)) {
+      out.push(s);
+      continue;
     }
-    
-    if (spaced) out.push(spaced);
+
+    const variants = new Set();
+    const base = titleCaseWords(s.replace(/-/g, ' ')).replace(/\s+/g, ' ').trim();
+    if (base) variants.add(base);
+
+    const sizeCandidate = s.replace(/[×]/g, 'x');
+    const sizeParts = sizeCandidate.split(/x/i).map(part => part.trim()).filter(Boolean);
+    const sizeLike = sizeParts.length >= 2 && sizeParts.every(part => /^[0-9'"′″\s\/.:-]+$/.test(part));
+    if (sizeLike) {
+      const normalizedParts = sizeParts.map(part => part.replace(/-/g, ' ').replace(/\s+/g, ' ').trim()).filter(Boolean);
+      const joinParts = delim => normalizedParts.join(delim).replace(/\s+/g, ' ').trim();
+      const collapsed = normalizedParts.join('x').replace(/\s+/g, '');
+
+      if (normalizedParts.length) {
+        const spaced = joinParts(' x ');
+        const spacedUpper = joinParts(' X ');
+        if (spaced) variants.add(spaced);
+        if (spacedUpper) variants.add(spacedUpper);
+        if (collapsed) variants.add(collapsed);
+
+        const hasQuote = normalizedParts.some(part => /['"′″]/.test(part));
+        const isPlainNumber = part => /^\d+(?:\s*\d\/\d)?$/.test(part);
+        if (!hasQuote && normalizedParts.every(isPlainNumber)) {
+          const withFeetParts = normalizedParts.map(part => `${part}'`);
+          const withFeet = withFeetParts.join(' x ');
+          const withFeetUpper = withFeetParts.join(' X ');
+          if (withFeet) variants.add(withFeet);
+          if (withFeetUpper) variants.add(withFeetUpper);
+        }
+      }
+    }
+
+    if (s) variants.add(s);
+
+    for (const v of variants) {
+      const finalValue = String(v).replace(/\s+/g, ' ').trim();
+      if (finalValue) out.push(finalValue);
+    }
   }
   return dedupeLoose(out);
 }

--- a/algolia-search-results.js
+++ b/algolia-search-results.js
@@ -19,10 +19,23 @@ function dedupe(arr) {
 function dedupeLoose(arr) {
   const out = []
   , seen = new Set();
-  const key = v => String(v).replace(/[\s-]+/g, '-').toLowerCase();
+  const key = v => {
+    const raw = String(v ?? '').trim();
+    if (!raw)
+      return '';
+
+    const lower = raw.toLowerCase();
+    const sizeish = lower.replace(/[×]/g, 'x');
+    // If the value looks like a size (numbers/quotes around an x), collapse whitespace/punctuation
+    if (/(?:\d|['"′″])\s*x\s*(?:\d|['"′″])/.test(sizeish)) {
+      return sizeish.replace(/[^0-9a-z]+/g, '');
+    }
+
+    return lower.replace(/[\s-]+/g, '-');
+  };
   for (const v of (arr || []).filter(Boolean)) {
     const k = key(v);
-    if (!seen.has(k)) {
+    if (k && !seen.has(k)) {
       seen.add(k);
       out.push(String(v));
     }
@@ -43,18 +56,58 @@ function normalizeFromUrlSingle(valueOrArray) {
     const s = String(raw).replace(/\+/g, ' ').trim();
 
     // Special handling for price groups - preserve hyphens for price ranges
-    const isPriceGroup = /^\$?\d+-\$?\d+$/.test(s);
-    let spaced;
-    if (isPriceGroup) {
-      // For price groups like "$1000-$2500", preserve the hyphen
-      spaced = s;
-    } else {
-      // For other values, convert hyphens to spaces as before
-      spaced = titleCaseWords(s.replace(/-/g, ' ')).replace(/\s+/g, ' ').trim();
+    if (/^\$?\d+-\$?\d+$/.test(s)) {
+      out.push(s);
+      continue;
     }
 
-    if (spaced)
-      out.push(spaced);
+    const variants = new Set();
+    const base = titleCaseWords(s.replace(/-/g, ' ')).replace(/\s+/g, ' ').trim();
+    if (base)
+      variants.add(base);
+
+    // Add dimension variants (e.g., 6x9 → 6 x 9, 6' x 9') to match stored facet values
+    const sizeCandidate = s.replace(/[×]/g, 'x');
+    const sizeParts = sizeCandidate.split(/x/i).map(part => part.trim()).filter(Boolean);
+    const sizeLike = sizeParts.length >= 2 && sizeParts.every(part => /^[0-9'"′″\s\/.:-]+$/.test(part));
+    if (sizeLike) {
+      const normalizedParts = sizeParts.map(part => part.replace(/-/g, ' ').replace(/\s+/g, ' ').trim()).filter(Boolean);
+      const joinParts = delim => normalizedParts.join(delim).replace(/\s+/g, ' ').trim();
+      const collapsed = normalizedParts.join('x').replace(/\s+/g, '');
+
+      if (normalizedParts.length) {
+        const spaced = joinParts(' x ');
+        const spacedUpper = joinParts(' X ');
+        if (spaced)
+          variants.add(spaced);
+        if (spacedUpper)
+          variants.add(spacedUpper);
+        if (collapsed)
+          variants.add(collapsed);
+
+        const hasQuote = normalizedParts.some(part => /['"′″]/.test(part));
+        const isPlainNumber = part => /^\d+(?:\s*\d\/\d)?$/.test(part);
+        if (!hasQuote && normalizedParts.every(isPlainNumber)) {
+          const withFeetParts = normalizedParts.map(part => `${part}'`);
+          const withFeet = withFeetParts.join(' x ');
+          const withFeetUpper = withFeetParts.join(' X ');
+          if (withFeet)
+            variants.add(withFeet);
+          if (withFeetUpper)
+            variants.add(withFeetUpper);
+        }
+      }
+    }
+
+    // Keep the raw trimmed value as a fallback
+    if (s)
+      variants.add(s);
+
+    for (const v of variants) {
+      const finalValue = String(v).replace(/\s+/g, ' ').trim();
+      if (finalValue)
+        out.push(finalValue);
+    }
   }
   return dedupeLoose(out);
 }


### PR DESCRIPTION
## Summary
- normalize keys used in loose dedupe to collapse size-like values such as `9x12`, `9 x 12`, and `9' x 12'`
- apply the same loose-dedupe improvement to the optimized landing page search script

## Testing
- node - <<'NODE' ... (size dedupe check)


------
https://chatgpt.com/codex/tasks/task_e_68dc96d426d8832f96aab0f857e47c90